### PR TITLE
Shared fns

### DIFF
--- a/examples/A2C.py
+++ b/examples/A2C.py
@@ -6,7 +6,7 @@ from stable_baselines3.common.evaluation import evaluate_policy
 
 env = gym.make('fishing-v0')
 model = A2C('MlpPolicy', env, verbose=0)
-model.learn(total_timesteps=500000)
+model.learn(total_timesteps=50000)
 
 ## simulate and plot results
 df = env.simulate(model, reps=10)

--- a/examples/DQN.R
+++ b/examples/DQN.R
@@ -1,0 +1,76 @@
+## R dependencies
+library(reticulate)
+library(tidyverse)
+
+
+## Python dependencies, via reticulate
+gym         <- import ("gym")
+gym_fishing <- import("gym_fishing")
+sb3         <- import ("stable_baselines3")
+os          <- import ("os")
+torch       <- import ("torch")
+np          <- import ("numpy")
+
+
+## NB: Most integers must be explicitly typed as such (e.g. `1L` for `1`)
+
+##  Turn CUDA off for reproducibility, if necessary.
+Sys.setenv("CUDA_VISIBLE_DEVICES" = "")
+
+## Set seeds
+torch$manual_seed(12345L)
+np$random$seed(12345L)
+
+## Initialize our environment
+ENV <- "fishing-v0"
+env <- gym$make(ENV, sigma = 0.05) # with some process noise
+
+## We will try training an ensemble of models
+
+model <- sb3$DQN('MlpPolicy', env, verbose=0L)
+model$learn(total_timesteps=200000L)
+
+
+
+## Here we go.  Sit tight, this is gonna take a while!
+
+## simulate models
+env$simulate(model, reps=50L)
+
+
+## infer a policy function from simulations?
+
+## Now what? Derive a policy function that is averaged over the models?
+
+
+## Evaluate model over n replicates
+reward <- map_dfr(models, function(model){
+  reward <- sb3$common$evaluation$evaluate_policy(model, env, n_eval_episodes=50L)
+  reward <- data.frame(mean = reward[[1]], sd = reward[[2]])
+  reward
+},
+.id = "model")
+
+##
+
+## repair NAs
+as.na <- function(x){
+  x[vapply(x, is.null, NA)] <- NA
+  as.numeric(x)
+}
+sims <- df %>%
+  as_tibble() %>%
+  mutate(state = as.na(state),
+         action = as.na(action),
+         reward = as.na(reward))
+
+## Plot
+p1 <- sims %>%
+  pivot_longer(cols = c(state, action, reward)) %>%
+  ggplot(aes(time, value, col=model)) + facet_wrap(~name,ncol=1)
+ggsave("results/sac.png")
+## Evaluate model
+p1
+
+
+

--- a/examples/DQN.py
+++ b/examples/DQN.py
@@ -15,6 +15,9 @@ model.learn(total_timesteps=int(1e5))
 df = env.simulate(model, reps=10)
 env.plot(df, "results/dqn.png")
 
+df = env.estimate_policyfn(model, reps=10)
+
+
 # Evaluate the agent
 mean_reward, std_reward = evaluate_policy(model, model.get_env(), n_eval_episodes=50)
 print("mean reward:", mean_reward, "std:", std_reward)

--- a/examples/PPO.py
+++ b/examples/PPO.py
@@ -6,7 +6,7 @@ from stable_baselines3.common.evaluation import evaluate_policy
 
 env = gym.make('fishing-v0')
 model = PPO('MlpPolicy', env, verbose=0)
-model.learn(total_timesteps=300000)
+model.learn(total_timesteps=100000)
 
 ## simulate and plot results
 df = env.simulate(model, reps=10)

--- a/examples/SAC.py
+++ b/examples/SAC.py
@@ -5,7 +5,7 @@ from stable_baselines3.common.evaluation import evaluate_policy
 
 env = gym.make('fishing-v3')
 model = SAC('MlpPolicy', env, verbose=0)
-model.learn(total_timesteps=200000)
+model.learn(total_timesteps=100000)
 
 ## simulate and plot results
 df = env.simulate(model, reps=10)

--- a/examples/TD3.py
+++ b/examples/TD3.py
@@ -5,7 +5,7 @@ from stable_baselines3.common.evaluation import evaluate_policy
 
 env = gym.make('fishing-v2', C = 0.01)
 model = TD3('MlpPolicy', env, verbose=0)
-model.learn(total_timesteps=200000)
+model.learn(total_timesteps=100000)
 
 ## simulate and plot results
 df = env.simulate(model, reps=10)

--- a/examples/replicates.R
+++ b/examples/replicates.R
@@ -53,8 +53,17 @@ policy %>% group_by(state, model) %>% summarize(action = mean(action)) %>%
   ggplot(aes(state, action, col=model)) + geom_line()
 
 
-policy %>% group_by(state) %>% summarize(action = mean(action)) %>%
-  ggplot(aes(state, action)) + geom_line()
+low <- function(x) quantile(x, probs = seq(0,1,by=0.05))[2]
+high <- function(x) quantile(x, probs = seq(0,1,by=0.05))[20]
+
+p2 <- policy %>% 
+  group_by(state) %>% 
+  summarise(mean_action = mean(action), low = low(action), high = high(action)) 
+
+p2 %>%
+  ggplot(aes(state, mean_action)) + 
+  geom_line() +
+  geom_ribbon(aes(ymin = low, ymax = high), alpha = 0.2)
 
 
 ## Evaluate model over n replicates
@@ -81,7 +90,7 @@ sims <- df %>%
          rep = as.integer(rep))
 
 ## Plot
- sims %>%
+sims %>%
   pivot_longer(cols = c(state, action, reward)) %>%
   ggplot(aes(time, value, col = rep)) + 
   geom_line(alpha=.8) +

--- a/examples/replicates.R
+++ b/examples/replicates.R
@@ -1,0 +1,92 @@
+## R dependencies
+library(reticulate)
+library(tidyverse)
+
+
+## Python dependencies, via reticulate
+gym         <- import ("gym")
+gym_fishing <- import("gym_fishing")
+sb3         <- import ("stable_baselines3")
+os          <- import ("os")
+torch       <- import ("torch")
+np          <- import ("numpy")
+
+
+## NB: Most integers must be explicitly typed as such (e.g. `1L` for `1`)
+
+##  Turn CUDA off for reproducibility, if necessary.
+Sys.setenv("CUDA_VISIBLE_DEVICES" = "0")
+
+## Set seeds
+torch$manual_seed(12345L)
+np$random$seed(12345L)
+
+## Initialize our environment
+ENV <- "fishing-v0"
+env <- gym$make(ENV, n_actions = 100L, sigma = 0.05) # with some process noise
+
+train <- function(env, algo = "DQN"){
+  init_model <- sb3[[algo]]
+  model <- init_model('MlpPolicy', env, verbose=0L)
+  model$learn(total_timesteps=200000L)
+}
+
+
+## Here we go.  Sit tight, this is gonna take a while!
+#models <- lapply(1:5, function(i) train(env, "DQN"))
+
+## save models
+#dir.create("results")
+#lapply(seq_along(models), function(i){
+#  models[[i]]$save(paste0("results/dqn", i))
+#})
+
+
+models <- lapply(paste0("examples/results/dqn", 1:5), sb3$DQN$load)
+## simulate models
+df <- map_dfr(models, env$simulate, reps=50L, .id = "model")
+
+policy <- map_dfr(models, env$policyfn, reps=500L, .id = "model")
+policy$action <- unlist(policy$action)
+
+policy %>% group_by(state, model) %>% summarize(action = mean(action)) %>%
+  ggplot(aes(state, action, col=model)) + geom_line()
+
+
+policy %>% group_by(state) %>% summarize(action = mean(action)) %>%
+  ggplot(aes(state, action)) + geom_line()
+
+
+## Evaluate model over n replicates
+reward <- 
+  map_dfr(models, function(model){
+    reward <- sb3$common$evaluation$evaluate_policy(model, env, n_eval_episodes=50L)
+    reward <- data.frame(mean = reward[[1]], sd = reward[[2]])
+    reward
+    },
+    .id = "model"
+  )
+    ##
+
+## repair NAs
+as.na <- function(x){
+  x[vapply(x, is.null, NA)] <- NA
+  as.numeric(x)
+}
+sims <- df %>%
+  as_tibble() %>%
+  mutate(state = as.na(state),
+         action = as.na(action)/100,
+         reward = as.na(reward),
+         rep = as.integer(rep))
+
+## Plot
+ sims %>%
+  pivot_longer(cols = c(state, action, reward)) %>%
+  ggplot(aes(time, value, col = rep)) + 
+  geom_line(alpha=.8) +
+  facet_grid(model~name, scales = "free")
+
+
+
+

--- a/examples/replicates.R
+++ b/examples/replicates.R
@@ -27,7 +27,7 @@ env <- gym$make(ENV, n_actions = 100L, sigma = 0.05) # with some process noise
 
 train <- function(env, algo = "SAC"){
   init_model <- sb3[[algo]]
-  model <- init_model('MlSAClicy', env, verbose=0L)
+  model <- init_model('MlpPolicy', env, verbose=0L)
   model$learn(total_timesteps=200000L)
 }
 

--- a/gym_fishing/envs/.ipynb_checkpoints/fishing_env-checkpoint.py
+++ b/gym_fishing/envs/.ipynb_checkpoints/fishing_env-checkpoint.py
@@ -51,8 +51,8 @@ class FishingEnv(gym.Env):
         
         if self.fish_population == 0:
             return self.fish_population, self.reward, True, {}
-        self.harvest_draw(action)
-        self.population_draw()
+        harvest_draw(self, action)
+        population_draw(self)
         self.reward += self.harvest / self.K
         if self.fish_population < 2e4:
             self.reward -= 10

--- a/gym_fishing/envs/fishing_cts_env.py
+++ b/gym_fishing/envs/fishing_cts_env.py
@@ -5,10 +5,7 @@ import gym
 from gym import spaces, logger, error, utils
 from gym.utils import seeding
 import numpy as np
-from csv import writer
-from pandas import read_csv, DataFrame
-import matplotlib.pyplot as plt
-
+from gym_fishing.envs.shared_env import harvest_draw, population_draw, csv_entry, simulate_mdp, plot_mdp
 
 class FishingCtsEnv(gym.Env):
     metadata = {'render.modes': ['human']}
@@ -46,21 +43,6 @@ class FishingCtsEnv(gym.Env):
         
         self.action_space = spaces.Box(np.array([0]), np.array([self.K]), dtype = np.float32)
         self.observation_space = spaces.Box(np.array([0]), np.array([2 * self.K]), dtype = np.float32)
-        
-    def harvest_draw(self, quota):
-        ## index (fish.population[0]) to avoid promoting float to array
-        self.harvest = min(self.fish_population[0], quota)
-        self.fish_population = max(self.fish_population - self.harvest, 0.0)
-        return self.harvest
-    
-    def population_draw(self):
-        self.fish_population = max(
-                                self.fish_population + self.r * self.fish_population \
-                                * (1.0 - self.fish_population / self.K) \
-                                + self.fish_population * self.sigma * np.random.normal(0,1),
-                                0.0)
-        return self.fish_population
-
     
     def step(self, action):
       
@@ -68,8 +50,8 @@ class FishingCtsEnv(gym.Env):
         action = np.clip(action, self.action_space.low, self.action_space.high)
         self.harvest = action
         
-        self.harvest_draw(self.harvest)
-        self.population_draw()
+        harvest_draw(self, self.harvest)
+        population_draw(self)
         
         ## should be the instanteous reward, not discounted
         reward = max(self.price * self.harvest, 0.0)
@@ -84,55 +66,26 @@ class FishingCtsEnv(gym.Env):
         
     
     def reset(self):
-        self.fish_population = np.array([self.init_state])
-        self.harvest = self.init_harvest
-        self.action = 0
-        self.years_passed = 0
-        return self.fish_population
-  
+      self.fish_population = np.array([self.init_state])
+      self.harvest = self.init_harvest
+      self.action = 0
+      self.years_passed = 0
+      return self.fish_population
+
+
     def render(self, mode='human'):
-      row_contents = [self.years_passed, 
-                      self.fish_population[0],
-                      self.action,
-                      self.reward]
-      csv_writer = writer(self.write_obj)
-      csv_writer.writerow(row_contents)
-      return row_contents
+      return csv_entry(self)
   
     def close(self):
-      pass
-
+      if(self.write_obj != None):
+        self.write_obj.close()
 
     def simulate(env, model, reps = 1):
-      row = []
-      for rep in range(reps):
-        obs = env.reset()
-        reward = 0
-        for t in range(env.Tmax-1):
-          action, _state = model.predict(obs)
-          row.append([t, obs, action, reward, rep])
-          obs, reward, done, info = env.step(action)
-          if done:
-            break
-        row.append([t+1, obs, None, reward, rep])
-      df = DataFrame(row, columns=['time', 'state', 'action', 'reward', "rep"])
-      return df
-    
-    def plot(self, df, output = "fishing.png"):
-      fig, axs = plt.subplots(3,1)
-      for i in range(np.max(df.rep)):
-        results = df[df.rep == i]
-        episode_reward = np.cumsum(results.reward)                    
-        axs[0].plot(results.time, results.state, color="blue", alpha=0.3)
-        axs[1].plot(results.time.iloc[:-1], results.action.iloc[:-1], color="blue", alpha=0.3)
-        axs[2].plot(results.time, episode_reward, color="blue", alpha=0.3)
+      return simulate_mdp(env, model, reps)
       
-      axs[0].set_ylabel('state')
-      axs[1].set_ylabel('action')
-      axs[2].set_ylabel('reward')
-      fig.tight_layout()
-      plt.savefig(output)
-      plt.close("all")
+    def plot(self, df, output = "results.png"):
+      return plot_mdp(self, df, output)
+      
 
-      
- 
+
+

--- a/gym_fishing/envs/fishing_cts_env.py
+++ b/gym_fishing/envs/fishing_cts_env.py
@@ -5,8 +5,9 @@ import gym
 from gym import spaces, logger, error, utils
 from gym.utils import seeding
 import numpy as np
-from gym_fishing.envs.shared_env import harvest_draw, population_draw, csv_entry, simulate_mdp, plot_mdp
-
+from gym_fishing.envs.shared_env import harvest_draw, population_draw, \
+  csv_entry, simulate_mdp, plot_mdp, estimate_policyfn
+  
 class FishingCtsEnv(gym.Env):
     metadata = {'render.modes': ['human']}
 
@@ -86,6 +87,7 @@ class FishingCtsEnv(gym.Env):
     def plot(self, df, output = "results.png"):
       return plot_mdp(self, df, output)
       
-
+    def policyfn(env, model, reps = 1):
+      return estimate_policyfn(env, model, reps)
 
 

--- a/gym_fishing/envs/fishing_env.py
+++ b/gym_fishing/envs/fishing_env.py
@@ -5,7 +5,8 @@ import gym
 from gym import spaces, logger, error, utils
 from gym.utils import seeding
 import numpy as np
-from gym_fishing.envs.shared_env import harvest_draw, population_draw, csv_entry, simulate_mdp, plot_mdp
+from gym_fishing.envs.shared_env import harvest_draw, population_draw, \
+  csv_entry, simulate_mdp, plot_mdp, estimate_policyfn
 
 class AbstractFishingEnv(gym.Env):
     metadata = {'render.modes': ['human']}
@@ -70,16 +71,16 @@ class AbstractFishingEnv(gym.Env):
         reward = max(self.price * self.harvest, 0.0)
         
         ## recording purposes only
-        self.action = action
-        self.reward = reward
+        self.action = int(action)
+        self.reward = np.array([reward])
         self.years_passed += 1
         done = bool(self.years_passed >= self.Tmax)
 
         if self.fish_population <= 0.0:
             done = True
-            return self.fish_population, reward, done, {}
+            return self.fish_population, self.reward, done, {}
 
-        return self.fish_population, reward, done, {}
+        return self.fish_population, self.reward, done, {}
         
     def reset(self):
         self.fish_population = np.array([self.init_state])
@@ -98,6 +99,9 @@ class AbstractFishingEnv(gym.Env):
 
     def simulate(env, model, reps = 1):
       return simulate_mdp(env, model, reps)
+
+    def policyfn(env, model, reps = 1):
+      return estimate_policyfn(env, model, reps)
       
     def plot(self, df, output = "results.png"):
       return plot_mdp(self, df, output)

--- a/gym_fishing/envs/fishing_model_error.py
+++ b/gym_fishing/envs/fishing_model_error.py
@@ -5,9 +5,7 @@ import gym
 from gym import spaces, logger, error, utils
 from gym.utils import seeding
 import numpy as np
-from csv import writer
-from pandas import read_csv, DataFrame
-import matplotlib.pyplot as plt
+from gym_fishing.envs.shared_env import harvest_draw, population_draw, csv_entry, simulate_mdp, plot_mdp
 
 
 class FishingModelError(gym.Env):
@@ -72,8 +70,8 @@ class FishingModelError(gym.Env):
         action = np.clip(action, self.action_space.low, self.action_space.high)
         self.harvest = action
         
-        self.harvest_draw(self.harvest)
-        self.population_draw()
+        harvest_draw(self, self.harvest)
+        population_draw(self)
         
         ## should be the instanteous reward, not discounted
         reward = max(self.price * self.harvest, 0.0)
@@ -97,49 +95,21 @@ class FishingModelError(gym.Env):
         return self.fish_population
   
     def render(self, mode='human'):
-      row_contents = [self.years_passed, 
-                      self.fish_population[0],
-                      self.action,
-                      self.reward]
-      csv_writer = writer(self.write_obj)
-      csv_writer.writerow(row_contents)
-      return row_contents
+        return csv_entry(self)
   
     def close(self):
-      if(self.write_obj != None):
-        self.write_obj.close()
-
+        if(self.write_obj != None):
+          self.write_obj.close()
 
     def simulate(env, model, reps = 1):
-      row = []
-      for rep in range(reps):
-        obs = env.reset()
-        reward = 0
-        for t in range(env.Tmax-1):
-          action, _state = model.predict(obs)
-          row.append([t, obs, action, reward, rep])
-          obs, reward, done, info = env.step(action)
-          if done:
-            break
-        row.append([t+1, obs, None, reward, rep])
-      df = DataFrame(row, columns=['time', 'state', 'action', 'reward', "rep"])
-      return df
-    
-    def plot(self, df, output = "fishing.png"):
-      fig, axs = plt.subplots(3,1)
-      for i in range(np.max(df.rep)):
-        results = df[df.rep == i]
-        episode_reward = np.cumsum(results.reward)                    
-        axs[0].plot(results.time, results.state, color="blue", alpha=0.3)
-        axs[1].plot(results.time.iloc[:-1], results.action.iloc[:-1], color="blue", alpha=0.3)
-        axs[2].plot(results.time, episode_reward, color="blue", alpha=0.3)
-      
-      axs[0].set_ylabel('state')
-      axs[1].set_ylabel('action')
-      axs[2].set_ylabel('reward')
-      fig.tight_layout()
-      plt.savefig(output)
-      plt.close("all")
+        return simulate_mdp(env, model, reps)
+        
+    def plot(self, df, output = "results.png"):
+        return plot_mdp(self, df, output)
+        
+
+
+
 
       
  

--- a/gym_fishing/envs/fishing_obs_error.py
+++ b/gym_fishing/envs/fishing_obs_error.py
@@ -5,9 +5,7 @@ import gym
 from gym import spaces, logger, error, utils
 from gym.utils import seeding
 import numpy as np
-from csv import writer
-from pandas import read_csv, DataFrame
-import matplotlib.pyplot as plt
+from gym_fishing.envs.shared_env import harvest_draw, population_draw, csv_entry, simulate_mdp, plot_mdp
 
 
 class FishingObsError(gym.Env):
@@ -52,28 +50,15 @@ class FishingObsError(gym.Env):
         self.observed = observation_noise(self.fish_population[0], 
                                   self.sigma_m, 
                                   self.observation_space)
-    def harvest_draw(self, quota):
-        ## index (fish.population[0]) to avoid promoting float to array
-        self.harvest = min(self.fish_population[0], quota)
-        self.fish_population = max(self.fish_population - self.harvest, 0.0)
-        return self.harvest
-    
-    def population_draw(self):
-        self.fish_population = max(
-                                self.fish_population + self.r * self.fish_population \
-                                * (1.0 - self.fish_population / self.K) \
-                                + self.fish_population * self.sigma * np.random.normal(0,1),
-                                0.0)
-        return self.fish_population
+   
 
-    
     def step(self, action):
       
         action = np.clip(action, self.action_space.low, self.action_space.high)
         self.harvest = action
         
-        self.harvest_draw(self.harvest)
-        self.population_draw()
+        harvest_draw(self, self.harvest)
+        population_draw(self)
         self.observed = observation_noise(self.fish_population[0], 
                                           self.sigma_m, 
                                           self.observation_space)
@@ -101,49 +86,21 @@ class FishingObsError(gym.Env):
         return self.fish_population
   
     def render(self, mode='human'):
-      row_contents = [self.years_passed, 
-                      self.fish_population[0],
-                      self.observed,
-                      self.action,
-                      self.reward]
-      csv_writer = writer(self.write_obj)
-      csv_writer.writerow(row_contents)
-      return row_contents
+      return csv_entry(self)
   
     def close(self):
       if(self.write_obj != None):
         self.write_obj.close()
 
     def simulate(env, model, reps = 1):
-      row = []
-      for rep in range(reps):
-        obs = env.reset()
-        reward = 0
-        for t in range(env.Tmax-1):
-          action, _state = model.predict(obs)
-          row.append([t, obs, action, reward, rep])
-          obs, reward, done, info = env.step(action)
-          if done:
-            break
-        row.append([t+1, obs, None, reward, rep])
-      df = DataFrame(row, columns=['time', 'state', 'action', 'reward', "rep"])
-      return df
-    
-    def plot(self, df, output = "fishing.png"):
-      fig, axs = plt.subplots(3,1)
-      for i in range(np.max(df.rep)):
-        results = df[df.rep == i]
-        episode_reward = np.cumsum(results.reward)                    
-        axs[0].plot(results.time, results.state, color="blue", alpha=0.3)
-        axs[1].plot(results.time.iloc[:-1], results.action.iloc[:-1], color="blue", alpha=0.3)
-        axs[2].plot(results.time, episode_reward, color="blue", alpha=0.3)
+      return simulate_mdp(env, model, reps)
       
-      axs[0].set_ylabel('state')
-      axs[1].set_ylabel('action')
-      axs[2].set_ylabel('reward')
-      fig.tight_layout()
-      plt.savefig(output)
-      plt.close("all")
+    def plot(self, df, output = "results.png"):
+      return plot_mdp(self, df, output)
+      
+
+
+
 
       
 

--- a/gym_fishing/envs/fishing_tipping_env.py
+++ b/gym_fishing/envs/fishing_tipping_env.py
@@ -5,9 +5,7 @@ import gym
 from gym import spaces, logger, error, utils
 from gym.utils import seeding
 import numpy as np
-from csv import writer
-from pandas import read_csv, DataFrame
-import matplotlib.pyplot as plt
+from gym_fishing.envs.shared_env import harvest_draw, population_draw, csv_entry, simulate_mdp, plot_mdp
 
 
 class FishingTippingEnv(gym.Env):
@@ -68,12 +66,11 @@ class FishingTippingEnv(gym.Env):
     
     def step(self, action):
       
-#        action = np.clip(action, 0, 2 * self.K)[0]
         action = np.clip(action, self.action_space.low, self.action_space.high)
         self.harvest = action
         
-        self.harvest_draw(self.harvest)
-        self.population_draw()
+        harvest_draw(self, self.harvest)
+        population_draw(self)
         
         ## should be the instanteous reward, not discounted
         reward = max(self.price * self.harvest, 0.0)
@@ -86,7 +83,6 @@ class FishingTippingEnv(gym.Env):
 
         return self.state, reward, done, {}
         
-    
     def reset(self):
         self.state = np.array([self.init_state])
         self.harvest = self.init_harvest
@@ -95,49 +91,20 @@ class FishingTippingEnv(gym.Env):
         return self.state
   
     def render(self, mode='human'):
-      row_contents = [self.years_passed, 
-                      self.state[0],
-                      self.action,
-                      self.reward]
-      csv_writer = writer(self.write_obj)
-      csv_writer.writerow(row_contents)
-      return row_contents
+        return csv_entry(self)
   
     def close(self):
-      if(self.write_obj != None):
-        self.write_obj.close()
-
+        if(self.write_obj != None):
+          self.write_obj.close()
 
     def simulate(env, model, reps = 1):
-      row = []
-      for rep in range(reps):
-        obs = env.reset()
-        reward = 0
-        for t in range(env.Tmax-1):
-          action, _state = model.predict(obs)
-          row.append([t, obs, action, reward, rep])
-          obs, reward, done, info = env.step(action)
-          if done:
-            break
-        row.append([t+1, obs, None, reward, rep])
-      df = DataFrame(row, columns=['time', 'state', 'action', 'reward', "rep"])
-      return df
-    
-    def plot(self, df, output = "fishing.png"):
-      fig, axs = plt.subplots(3,1)
-      for i in range(np.max(df.rep)):
-        results = df[df.rep == i]
-        episode_reward = np.cumsum(results.reward)                    
-        axs[0].plot(results.time, results.state, color="blue", alpha=0.3)
-        axs[1].plot(results.time.iloc[:-1], results.action.iloc[:-1], color="blue", alpha=0.3)
-        axs[2].plot(results.time, episode_reward, color="blue", alpha=0.3)
-      
-      axs[0].set_ylabel('state')
-      axs[1].set_ylabel('action')
-      axs[2].set_ylabel('reward')
-      fig.tight_layout()
-      plt.savefig(output)
-      plt.close("all")
+        return simulate_mdp(env, model, reps)
+        
+    def plot(self, df, output = "results.png"):
+        return plot_mdp(self, df, output)
+        
+
+
 
       
  

--- a/gym_fishing/envs/shared_env.py
+++ b/gym_fishing/envs/shared_env.py
@@ -1,0 +1,77 @@
+import numpy as np
+from csv import writer
+from pandas import read_csv, DataFrame
+import matplotlib.pyplot as plt
+
+## Shared methods
+def harvest_draw(self, quota):
+    """
+    Select a value to harvest at each time step.
+    """
+    
+    ## index (fish.population[0]) to avoid promoting float to array
+    self.harvest = min(self.fish_population[0], quota)
+    self.fish_population = max(self.fish_population - self.harvest, 0.0)
+    return self.harvest
+
+def population_draw(self):
+    """
+    Select a value for population to grow or decrease at each time step.
+    """
+    self.fish_population = max(
+                            self.fish_population + self.r * self.fish_population \
+                            * (1.0 - self.fish_population / self.K) \
+                            + self.fish_population * self.sigma * np.random.normal(0,1),
+                            0.0)
+    return self.fish_population
+
+
+def csv_entry(self):
+  row_contents = [self.years_passed, 
+                  self.state[0],
+                  self.action,
+                  self.reward]
+  csv_writer = writer(self.write_obj)
+  csv_writer.writerow(row_contents)
+  return row_contents
+    
+def simulate_mdp(env, model, reps = 1):
+  row = []
+  for rep in range(reps):
+    obs = env.reset()
+    for t in range(env.Tmax):
+      action, _state = model.predict(obs)
+      obs, reward, done, info = env.step(action)
+      row.append([t, obs, action, reward, rep])
+      if done:
+        break
+  df = DataFrame(row, columns=['time', 'state', 'action', 'reward', "rep"])
+  return df
+
+
+def estimate_policyfn(env, model, reps = 1):
+  row = []
+  for rep in range(reps):
+    for obs in range(2*env.K):
+      action, _state = model.predict(obs)
+      row.append([obs, action, rep])
+      if done:
+        break
+  df = DataFrame(row, columns=['state', 'action', 'rep'])
+  return df
+
+def plot_mdp(self, df, output = "results.png"):
+  fig, axs = plt.subplots(3,1)
+  for i in range(np.max(df.rep)):
+    results = df[df.rep == i]
+    episode_reward = np.cumsum(results.reward)                    
+    axs[0].plot(results.time, results.state, color="blue", alpha=0.3)
+    axs[1].plot(results.time, results.action, color="blue", alpha=0.3)
+    axs[2].plot(results.time, episode_reward, color="blue", alpha=0.3)
+  
+  axs[0].set_ylabel('state')
+  axs[1].set_ylabel('action')
+  axs[2].set_ylabel('reward')
+  fig.tight_layout()
+  plt.savefig(output)
+  plt.close("all")

--- a/gym_fishing/envs/shared_env.py
+++ b/gym_fishing/envs/shared_env.py
@@ -42,21 +42,24 @@ def simulate_mdp(env, model, reps = 1):
     for t in range(env.Tmax):
       action, _state = model.predict(obs)
       obs, reward, done, info = env.step(action)
-      row.append([t, obs, action, reward, rep])
+      row.append([t, obs, action, reward, int(rep)])
       if done:
         break
   df = DataFrame(row, columns=['time', 'state', 'action', 'reward', "rep"])
   return df
 
 
-def estimate_policyfn(env, model, reps = 1):
+def estimate_policyfn(env, model, reps = 1, n = 50):
   row = []
+  state_range = np.linspace(env.observation_space.low, 
+                            env.observation_space.high, 
+                            num=n, 
+                            dtype=env.observation_space.dtype)
   for rep in range(reps):
-    for obs in range(2*env.K):
+    for obs in state_range:
       action, _state = model.predict(obs)
-      row.append([obs, action, rep])
-      if done:
-        break
+      row.append([obs[0], action, rep])
+  
   df = DataFrame(row, columns=['state', 'action', 'rep'])
   return df
 

--- a/gym_fishing/envs/shared_env.py
+++ b/gym_fishing/envs/shared_env.py
@@ -42,7 +42,7 @@ def simulate_mdp(env, model, reps = 1):
     for t in range(env.Tmax):
       action, _state = model.predict(obs)
       obs, reward, done, info = env.step(action)
-      row.append([t, obs, action, reward, int(rep)])
+      row.append([t, obs[0], action, reward, int(rep)])
       if done:
         break
   df = DataFrame(row, columns=['time', 'state', 'action', 'reward', "rep"])


### PR DESCRIPTION
@mlap just a quick pass here trying to tidy things up a little with a bit more consistent use of shared functions in the gym.  Would be even better to add class inheritance so the methods can inherit their shared bits directly.  One thing I'm not clear on is how to do inheritance with custom `init` methods; e.g. since the `init` method for, say, the tipping point gym will take different structure.  

Really this probably suggests the init method itself ought to just be refactored into something a little more generic (e.g. pass a dictionary of `pars` for the growth function, instead of hardcoding `K`, `r` etc into the init.  Unfortunately that would be a breaking change to user-facing code at this point so not sure if it's a good idea.  

Also in the PR, I snuck in an additional method to try and estimate what "policy function" the agent is following.  Instead of running a simulated management scenario, it just steps through the state space on a uniform grid, and sees what action is proposed for each possible state (and does this `reps` number of times).  Not sure if that's helpful or not (obviously the agent will not have a well-tuned policy for states that it sees only rarely or never during training) but I think it can be useful in understanding the agent's behavior more generally (i.e. in transfer learning, or in comparison to standard theory).  Lemme know what you think.   