### PR TITLE
Adding support for vectorized environments

### DIFF
--- a/gym_fishing/envs/shared_env.py
+++ b/gym_fishing/envs/shared_env.py
@@ -11,12 +11,20 @@ def csv_entry(self):
     csv_writer.writerow(row_contents)
     return row_contents
 
+
 def df_entry_vec(df, env, rep, obs, action, reward, t):
-    for i, e in enumerate(range(len(df.index), len(df.index)+env.num_envs)):
-        fish_population = env.env_method("get_fish_population", (obs[i],),\
-                                                           indices=i)[0][0]
-        df.loc[e] = [t, fish_population, action[i][0], reward[i], \
-                                            (rep*env.num_envs) + i]
+    for i, e in enumerate(range(len(df.index), len(df.index) + env.num_envs)):
+        fish_population = env.env_method(
+            "get_fish_population", (obs[i],), indices=i
+        )[0][0]
+        df.loc[e] = [
+            t,
+            fish_population,
+            action[i][0],
+            reward[i],
+            (rep * env.num_envs) + i,
+        ]
+
 
 def simulate_mdp(env, model, reps=1):
     row = []
@@ -45,14 +53,17 @@ def simulate_mdp(env, model, reps=1):
     df = DataFrame(row, columns=["time", "state", "action", "reward", "rep"])
     return df
 
+
 def simulate_mdp_vec(env, model, n_eval_episodes):
-    assert n_eval_episodes % env.num_envs == 0, "Error: number of \
+    assert (
+        n_eval_episodes % env.num_envs == 0
+    ), "Error: number of \
                      evaluations needs to be divisible by the number \
                      of parallel environments"
 
     # Since performed in parallel, need to account for number of envs
     reps = int(n_eval_episodes / env.num_envs)
-    df = DataFrame(columns=['time', 'state', 'action', 'reward', 'rep'])
+    df = DataFrame(columns=["time", "state", "action", "reward", "rep"])
     for rep in range(reps):
         obs = env.reset()
         state = None
@@ -63,9 +74,10 @@ def simulate_mdp_vec(env, model, n_eval_episodes):
             df_entry_vec(df, env, rep, obs, action, reward, t)
             action, state = model.predict(obs, state=state, mask=done)
             obs, reward, done, info = env.step(action)
-        df_entry_vec(df, env, rep, obs, action, reward, t+1)
+        df_entry_vec(df, env, rep, obs, action, reward, t + 1)
 
     return df
+
 
 def estimate_policyfn(env, model, reps=1, n=50):
     row = []

--- a/gym_fishing/envs/shared_env.py
+++ b/gym_fishing/envs/shared_env.py
@@ -49,11 +49,9 @@ def simulate_mdp_vec(env, model, n_eval_episodes):
 
     # Since performed in parallel, need to account for number of envs
     reps = int(n_eval_episodes / env.num_envs)
-    df = pd.DataFrame(columns=['time', 'state', 'action', 'reward', 'rep'])
+    df = DataFrame(columns=['time', 'state', 'action', 'reward', 'rep'])
     for rep in range(reps):
         obs = env.reset()
-        quota = []
-        reward = []
         state = None
         done = [False for _ in range(env.num_envs)]
         action = [[env.action_space.low[0]] for _ in range(env.num_envs)]

--- a/gym_fishing/envs/shared_env.py
+++ b/gym_fishing/envs/shared_env.py
@@ -11,6 +11,10 @@ def csv_entry(self):
     csv_writer.writerow(row_contents)
     return row_contents
 
+def df_entry_vec(df, env, rep, obs, action, reward, t):
+    for i, e in enumerate(range(len(df.index), len(df.index)+env.num_envs)):
+        fish_population = env.env_method("get_fish_population", (obs[i],), indices=i)[0][0]
+        df.loc[e] = [t, fish_population, action[i][0], reward[i], (rep*env.num_envs) + i]
 
 def simulate_mdp(env, model, reps=1):
     row = []
@@ -39,6 +43,28 @@ def simulate_mdp(env, model, reps=1):
     df = DataFrame(row, columns=["time", "state", "action", "reward", "rep"])
     return df
 
+def simulate_mdp_vec(env, model, n_eval_episodes):
+    assert n_eval_episodes % env.num_envs == 0, "Error: number of evaluations needs to\
+                                  be divisible by the number of parallel environments"
+
+    # Since performed in parallel, need to account for number of envs
+    reps = int(n_eval_episodes / env.num_envs)
+    df = pd.DataFrame(columns=['time', 'state', 'action', 'reward', 'rep'])
+    for rep in range(reps):
+        obs = env.reset()
+        quota = []
+        reward = []
+        state = None
+        done = [False for _ in range(env.num_envs)]
+        action = [[env.action_space.low[0]] for _ in range(env.num_envs)]
+        reward = [0 for _ in range(env.num_envs)]
+        for t in range(env.get_attr("Tmax")[0]):
+            df_entry_vec(df, env, rep, obs, action, reward, t)
+            action, state = model.predict(obs, state=state, mask=done)
+            obs, reward, done, info = env.step(action)
+        df_entry_vec(df, env, rep, obs, action, reward, t+1)
+
+    return df
 
 def estimate_policyfn(env, model, reps=1, n=50):
     row = []

--- a/gym_fishing/envs/shared_env.py
+++ b/gym_fishing/envs/shared_env.py
@@ -13,8 +13,10 @@ def csv_entry(self):
 
 def df_entry_vec(df, env, rep, obs, action, reward, t):
     for i, e in enumerate(range(len(df.index), len(df.index)+env.num_envs)):
-        fish_population = env.env_method("get_fish_population", (obs[i],), indices=i)[0][0]
-        df.loc[e] = [t, fish_population, action[i][0], reward[i], (rep*env.num_envs) + i]
+        fish_population = env.env_method("get_fish_population", (obs[i],),\
+                                                           indices=i)[0][0]
+        df.loc[e] = [t, fish_population, action[i][0], reward[i], \
+                                            (rep*env.num_envs) + i]
 
 def simulate_mdp(env, model, reps=1):
     row = []
@@ -44,8 +46,9 @@ def simulate_mdp(env, model, reps=1):
     return df
 
 def simulate_mdp_vec(env, model, n_eval_episodes):
-    assert n_eval_episodes % env.num_envs == 0, "Error: number of evaluations needs to\
-                                  be divisible by the number of parallel environments"
+    assert n_eval_episodes % env.num_envs == 0, "Error: number of \
+                     evaluations needs to be divisible by the number \
+                     of parallel environments"
 
     # Since performed in parallel, need to account for number of envs
     reps = int(n_eval_episodes / env.num_envs)


### PR DESCRIPTION
Hi @cboettig, just made some very small additions here. I have recently been looking at training a recurrent policy on v1, and I was having problems using a recurrent agent with the former `shared_env.py` utilities. Added enough here so that I can make plots, but did not refresh myself to see if there are any other area where changes could be made.